### PR TITLE
fix: event tag generated link references

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -67,7 +67,7 @@ function saveOutputFileContent() {
 
 function generateLink(config){
   var memberOf = (config.memberof || '').replace(/([^\a-z]+)/gi, '-');
-  var link = (memberOf.length ? memberOf + '-' : '') + config.name;
+  var link = (memberOf.length ? memberOf + '-' : '') + (config.name ? config.name.replace(/([^\a-z]+)/gi, '-') : '' );
   return link;
 }
 
@@ -329,6 +329,7 @@ function generate(title, docs, filename, resolveLinks) {
         var hash = link
           .replace(/\.html/, '')
           .replace(/([^\a-z"]+)/gi, '-')
+          .replace(/-event-/, '-')
           .replace(/^"/, '"#');
 
         html = html.replace(link, hash).replace(/global-/, '');


### PR DESCRIPTION
[@event](http://usejsdoc.org/tags-event.html) tag link references were generated to include the `event` namespace.

e.g. a link reference such as `[THE_EVENT]{@link SomeClass.event:THE_EVENT}` would result in a generated link of `href="http://example.com/index.html#SomeClass-event-THE-EVENT"`.

However, the actual element `id` and nav link to the event would be using this fragment: `SomeClass-THE_EVENT`.

This fix:

1. rationalizes link generation to use the standard separator of `-` for generated links; and
2. removes the event reference namespace of `-event-` for the single `index.html` output file.

If there is a preferred approach to dealing with the `event` namespace in particular, lmk and I can update accordingly.

/john