### PR TITLE
jsdoc 3.5 @hideconstructor handling

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -142,7 +142,7 @@ function needsSignature(doclet) {
   var needsSig = false;
 
   // function and class definitions always get a signature
-  if (doclet.kind === 'function' || doclet.kind === 'class') {
+  if ((doclet.kind === 'function' || doclet.kind === 'class') && !doclet.hideconstructor) {
     needsSig = true;
   }
   // typedefs that contain functions get a signature, too
@@ -371,7 +371,7 @@ function attachModuleSymbols(doclets, modules) {
         .map(function(symbol) {
           symbol = doop(symbol);
 
-          if (symbol.kind === 'class' || symbol.kind === 'function') {
+          if ((symbol.kind === 'class' || symbol.kind === 'function') && !symbol.hideconstructor) {
             symbol.name = symbol.name.replace('module:', '(require("') + '"))';
           }
 

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -4,12 +4,12 @@ var self = this;
 
 ?>
 <?js if (data.kind !== 'module') { ?>
-    <?js if (data.kind === 'class' && data.classdesc) { ?>
+    <?js if (data.kind === 'class' && !data.hideconstructor && data.classdesc) { ?>
     <h2>Constructor</h2>
     <?js } ?>
 
-    <h4 class="name foo" id="<?js= self.generateLink(data) ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
-    name + (data.signature || '') ?></h4>
+    <h4 class="name" id="<?js= self.generateLink(data) ?>"><?js= data.attribs + (data.kind === 'class' && !data.hideconstructor ? 'new ' : '') +
+    (data.kind === 'class' && data.hideconstructor ? '' :  name + (data.signature || '')) ?></h4>
 
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>


### PR DESCRIPTION
Added handling of `@hideconstructor`

* https://github.com/jsdoc3/jsdoc3.github.com/issues/168

Example output is below. The publisher and templates appear to be backward compatible to at least the version tested below.

## prior to pull request
(_JSDoc 3.4.2 (Mon, 03 Oct 2016 18:14:32 GMT)_)
```
/**
 * @classdesc Pubfood event emitter
 * @class
 * @hideconstructor
*/
```
*=> HTML such as*

```
<header id="PubfoodEvent">
<h2>
        PubfoodEvent
        </h2>
<div class="class-description">Pubfood event emitter</div>
</header>

<article>
    <div class="container-overview">
<h2>Constructor</h2>
<h4 class="name" id="PubfoodEvent"><span class="type-signature"></span>new PubfoodEvent<span class="signature">()</span><span class="type-signature"></span></h4>
```

## after the pull request
(_JSDoc 3.5.5 (Thu, 14 Sep 2017 02:51:54 GMT)_)

```
<section id="class-PubfoodEvent">
  <a href="#top" class="back-to-top">back to top ⇧</a>

<header id="PubfoodEvent">
<h2>
        PubfoodEvent
        </h2>
<div class="class-description">Pubfood event emitter</div>
</header>

<article>
    <div class="container-overview">
<h4 class="name" id="PubfoodEvent"></h4>
```